### PR TITLE
Feat/display relevant info

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -8,7 +8,8 @@
 - After WiFi connect, tracker fetches aircraft data from OpenSky.
 - LCD shows:
   - WiFi status
-  - nearest aircraft callsign, distance, altitude, heading
+  - nearest aircraft callsign, type, distance, altitude, heading
+  - best-effort route (origin/destination), when available
   - or `Aircraft: no data` when nothing is available.
 
 ## Implemented Components
@@ -19,6 +20,8 @@
     - OAuth2 client credentials flow (preferred)
     - Basic auth fallback (legacy)
   - Fetches `/api/states/all` with bbox from configured lat/lon/radius.
+  - Tries to enrich nearest aircraft with type/registration/route using `api.adsbdb.com`.
+  - Fallback route enrichment using OpenSky `/api/flights/aircraft`.
   - Filters out aircraft on ground (`on_ground == true`).
   - Selects nearest aircraft using haversine distance.
 - `main/hello_world_main.c`:
@@ -50,7 +53,7 @@
 
 ## Known Limitations
 - Source endpoint (`states/all`) does not provide aircraft model/type directly.
-- Route origin/destination is not available from `states/all`; requires additional lookup endpoints.
+- Type and route depend on third-party enrichment availability and may be missing.
 - Token is currently fetched per tracker cycle; no token cache yet.
 
 ## Security Notes

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -7,7 +7,7 @@
 - Device boots, initializes LCD + LVGL + WiFi.
 - After WiFi connect, tracker fetches aircraft data from OpenSky.
 - LCD shows:
-  - WiFi status/IP/RSSI
+  - WiFi status
   - nearest aircraft callsign, distance, altitude, heading
   - or `Aircraft: no data` when nothing is available.
 

--- a/main/aircraft_tracker.c
+++ b/main/aircraft_tracker.c
@@ -1,6 +1,7 @@
 #include "aircraft_tracker.h"
 #include "config.h"
 #include <ctype.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,7 +16,10 @@ static const char *TAG = "aircraft_tracker";
 
 #define RESP_BUF_SIZE 24576
 #define TOKEN_RESP_BUF_SIZE 4096
+#define FLIGHTS_RESP_BUF_SIZE 8192
+#define ADSBDB_RESP_BUF_SIZE 8192
 #define ACCESS_TOKEN_MAX_LEN 2048
+#define ENRICHMENT_CACHE_TTL_SEC 300
 #define DEG_TO_RAD (0.01745329251994329576923690768489)
 
 typedef struct {
@@ -23,6 +27,15 @@ typedef struct {
     size_t len;
     size_t cap;
 } http_resp_buf_t;
+
+typedef struct {
+    bool valid;
+    char icao24[16];
+    char callsign[16];
+    aircraft_info_t data;
+} enrichment_cache_t;
+
+static enrichment_cache_t s_enrichment_cache = {0};
 
 static esp_err_t http_event_handler(esp_http_client_event_t *evt)
 {
@@ -87,6 +100,18 @@ static void trim_spaces(char *str)
     while (end >= str && isspace((unsigned char)*end)) {
         *end = '\0';
         end--;
+    }
+}
+
+static void copy_json_string(cJSON *obj, const char *key, char *out, size_t out_size)
+{
+    cJSON *item;
+    if (obj == NULL || key == NULL || out == NULL || out_size == 0) {
+        return;
+    }
+    item = cJSON_GetObjectItem(obj, key);
+    if (cJSON_IsString(item) && item->valuestring != NULL) {
+        snprintf(out, out_size, "%s", item->valuestring);
     }
 }
 
@@ -175,6 +200,29 @@ static esp_err_t http_get_oauth_token(char *token_out, size_t token_out_size)
     return ESP_OK;
 }
 
+static void set_auth_header_if_available(esp_http_client_handle_t client)
+{
+    if (strlen(TRACKER_OPENSKY_CLIENT_ID) > 0 && strlen(TRACKER_OPENSKY_CLIENT_SECRET) > 0) {
+        char access_token[ACCESS_TOKEN_MAX_LEN] = {0};
+        char auth_header[ACCESS_TOKEN_MAX_LEN + 16];
+        if (http_get_oauth_token(access_token, sizeof(access_token)) == ESP_OK) {
+            snprintf(auth_header, sizeof(auth_header), "Bearer %s", access_token);
+            esp_http_client_set_header(client, "Authorization", auth_header);
+        }
+    } else if (strlen(TRACKER_OPENSKY_USERNAME) > 0) {
+        char userpass[160];
+        unsigned char b64[240];
+        size_t b64_len = 0;
+        char auth_header[280];
+
+        snprintf(userpass, sizeof(userpass), "%s:%s", TRACKER_OPENSKY_USERNAME, TRACKER_OPENSKY_PASSWORD);
+        if (mbedtls_base64_encode(b64, sizeof(b64), &b64_len, (const unsigned char *)userpass, strlen(userpass)) == 0) {
+            snprintf(auth_header, sizeof(auth_header), "Basic %.*s", (int)b64_len, b64);
+            esp_http_client_set_header(client, "Authorization", auth_header);
+        }
+    }
+}
+
 static esp_err_t http_get_states(char *out_json, size_t out_size)
 {
     double lat = tracker_home_lat();
@@ -209,28 +257,7 @@ static esp_err_t http_get_states(char *out_json, size_t out_size)
         return ESP_FAIL;
     }
 
-    if (strlen(TRACKER_OPENSKY_CLIENT_ID) > 0 && strlen(TRACKER_OPENSKY_CLIENT_SECRET) > 0) {
-        char access_token[ACCESS_TOKEN_MAX_LEN] = {0};
-        char auth_header[ACCESS_TOKEN_MAX_LEN + 16];
-        esp_err_t token_err = http_get_oauth_token(access_token, sizeof(access_token));
-        if (token_err != ESP_OK) {
-            esp_http_client_cleanup(client);
-            return token_err;
-        }
-        snprintf(auth_header, sizeof(auth_header), "Bearer %s", access_token);
-        esp_http_client_set_header(client, "Authorization", auth_header);
-    } else if (strlen(TRACKER_OPENSKY_USERNAME) > 0) {
-        char userpass[160];
-        unsigned char b64[240];
-        size_t b64_len = 0;
-        char auth_header[280];
-
-        snprintf(userpass, sizeof(userpass), "%s:%s", TRACKER_OPENSKY_USERNAME, TRACKER_OPENSKY_PASSWORD);
-        if (mbedtls_base64_encode(b64, sizeof(b64), &b64_len, (const unsigned char *)userpass, strlen(userpass)) == 0) {
-            snprintf(auth_header, sizeof(auth_header), "Basic %.*s", (int)b64_len, b64);
-            esp_http_client_set_header(client, "Authorization", auth_header);
-        }
-    }
+    set_auth_header_if_available(client);
 
     esp_err_t err = esp_http_client_perform(client);
     if (err != ESP_OK) {
@@ -253,6 +280,284 @@ static esp_err_t http_get_states(char *out_json, size_t out_size)
     return ESP_OK;
 }
 
+static esp_err_t http_get_json(const char *url, char *out_json, size_t out_size)
+{
+    http_resp_buf_t resp = {
+        .buf = out_json,
+        .len = 0,
+        .cap = out_size,
+    };
+
+    esp_http_client_config_t cfg = {
+        .url = url,
+        .method = HTTP_METHOD_GET,
+        .timeout_ms = 12000,
+        .event_handler = http_event_handler,
+        .user_data = &resp,
+        .buffer_size = 4096,
+        .buffer_size_tx = 2048,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (client == NULL) {
+        return ESP_FAIL;
+    }
+
+    esp_err_t err = esp_http_client_perform(client);
+    if (err != ESP_OK) {
+        esp_http_client_cleanup(client);
+        return err;
+    }
+
+    if (esp_http_client_get_status_code(client) != 200) {
+        esp_http_client_cleanup(client);
+        return ESP_FAIL;
+    }
+
+    esp_http_client_cleanup(client);
+    return (resp.len > 0) ? ESP_OK : ESP_ERR_INVALID_RESPONSE;
+}
+
+static esp_err_t http_get_flights_for_aircraft(const char *icao24, int64_t begin_unix, int64_t end_unix, char *out_json, size_t out_size)
+{
+    char url[256];
+    http_resp_buf_t resp = {
+        .buf = out_json,
+        .len = 0,
+        .cap = out_size,
+    };
+
+    snprintf(url, sizeof(url),
+             "https://opensky-network.org/api/flights/aircraft?icao24=%s&begin=%" PRId64 "&end=%" PRId64,
+             icao24, begin_unix, end_unix);
+
+    esp_http_client_config_t cfg = {
+        .url = url,
+        .method = HTTP_METHOD_GET,
+        .timeout_ms = 12000,
+        .event_handler = http_event_handler,
+        .user_data = &resp,
+        .buffer_size = 4096,
+        .buffer_size_tx = 2048,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (client == NULL) {
+        return ESP_FAIL;
+    }
+    set_auth_header_if_available(client);
+
+    esp_err_t err = esp_http_client_perform(client);
+    if (err != ESP_OK) {
+        esp_http_client_cleanup(client);
+        return err;
+    }
+
+    int status = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+    if (status != 200) {
+        return ESP_FAIL;
+    }
+
+    return (resp.len > 0) ? ESP_OK : ESP_ERR_INVALID_RESPONSE;
+}
+
+static bool airport_or_empty(cJSON *item, char *out, size_t out_size)
+{
+    if (cJSON_IsString(item) && item->valuestring != NULL) {
+        snprintf(out, out_size, "%s", item->valuestring);
+        return out[0] != '\0';
+    }
+    out[0] = '\0';
+    return false;
+}
+
+static void fill_route_from_recent_flights(const char *icao24, const char *callsign, int64_t server_time_unix, aircraft_info_t *info)
+{
+    char *response = NULL;
+    cJSON *root = NULL;
+    bool prefer_callsign = false;
+    int64_t best_last_seen = -1;
+    char best_departure[8] = {0};
+    char best_arrival[8] = {0};
+    size_t i;
+
+    if (icao24 == NULL || icao24[0] == '\0' || server_time_unix <= 0 || info == NULL) {
+        return;
+    }
+
+    response = calloc(1, FLIGHTS_RESP_BUF_SIZE);
+    if (response == NULL) {
+        return;
+    }
+
+    if (http_get_flights_for_aircraft(icao24, server_time_unix - 21600, server_time_unix + 300, response, FLIGHTS_RESP_BUF_SIZE) != ESP_OK) {
+        free(response);
+        return;
+    }
+
+    root = cJSON_Parse(response);
+    free(response);
+    response = NULL;
+    if (!cJSON_IsArray(root)) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    for (i = 0; i < (size_t)cJSON_GetArraySize(root); i++) {
+        cJSON *flight = cJSON_GetArrayItem(root, (int)i);
+        cJSON *dep = cJSON_GetObjectItem(flight, "estDepartureAirport");
+        cJSON *arr = cJSON_GetObjectItem(flight, "estArrivalAirport");
+        cJSON *last_seen_item = cJSON_GetObjectItem(flight, "lastSeen");
+        cJSON *flight_callsign_item = cJSON_GetObjectItem(flight, "callsign");
+        bool has_dep;
+        bool has_arr;
+        bool callsign_match = false;
+        int64_t last_seen = 0;
+        char dep_code[8] = {0};
+        char arr_code[8] = {0};
+
+        if (!cJSON_IsObject(flight)) {
+            continue;
+        }
+
+        has_dep = airport_or_empty(dep, dep_code, sizeof(dep_code));
+        has_arr = airport_or_empty(arr, arr_code, sizeof(arr_code));
+        if (!has_dep && !has_arr) {
+            continue;
+        }
+
+        if (cJSON_IsNumber(last_seen_item)) {
+            last_seen = (int64_t)last_seen_item->valuedouble;
+        }
+
+        if (cJSON_IsString(flight_callsign_item) && flight_callsign_item->valuestring && callsign && callsign[0]) {
+            char tmp_callsign[16];
+            snprintf(tmp_callsign, sizeof(tmp_callsign), "%s", flight_callsign_item->valuestring);
+            trim_spaces(tmp_callsign);
+            callsign_match = (strcmp(tmp_callsign, callsign) == 0);
+        }
+
+        if (callsign_match && !prefer_callsign) {
+            prefer_callsign = true;
+            best_last_seen = -1;
+        }
+        if (prefer_callsign && !callsign_match) {
+            continue;
+        }
+
+        if (last_seen >= best_last_seen) {
+            best_last_seen = last_seen;
+            snprintf(best_departure, sizeof(best_departure), "%s", has_dep ? dep_code : "");
+            snprintf(best_arrival, sizeof(best_arrival), "%s", has_arr ? arr_code : "");
+        }
+    }
+
+    cJSON_Delete(root);
+
+    if (best_last_seen >= 0) {
+        snprintf(info->origin_airport, sizeof(info->origin_airport), "%s", best_departure);
+        snprintf(info->destination_airport, sizeof(info->destination_airport), "%s", best_arrival);
+    }
+}
+
+static void fill_from_adsbdb(const char *icao24, const char *callsign, aircraft_info_t *info)
+{
+    char *response = NULL;
+    cJSON *root = NULL;
+    cJSON *resp_obj = NULL;
+    char url[256];
+
+    if (icao24 == NULL || icao24[0] == '\0' || info == NULL) {
+        return;
+    }
+
+    if (s_enrichment_cache.valid &&
+        strcmp(s_enrichment_cache.icao24, icao24) == 0 &&
+        strcmp(s_enrichment_cache.callsign, (callsign != NULL) ? callsign : "") == 0) {
+        if (s_enrichment_cache.data.registration[0] != '\0') {
+            snprintf(info->registration, sizeof(info->registration), "%s", s_enrichment_cache.data.registration);
+        }
+        if (s_enrichment_cache.data.aircraft_type_code[0] != '\0') {
+            snprintf(info->aircraft_type_code, sizeof(info->aircraft_type_code), "%s", s_enrichment_cache.data.aircraft_type_code);
+        }
+        if (s_enrichment_cache.data.aircraft_type_name[0] != '\0') {
+            snprintf(info->aircraft_type_name, sizeof(info->aircraft_type_name), "%s", s_enrichment_cache.data.aircraft_type_name);
+        }
+        if (s_enrichment_cache.data.origin_airport[0] != '\0') {
+            snprintf(info->origin_airport, sizeof(info->origin_airport), "%s", s_enrichment_cache.data.origin_airport);
+        }
+        if (s_enrichment_cache.data.destination_airport[0] != '\0') {
+            snprintf(info->destination_airport, sizeof(info->destination_airport), "%s", s_enrichment_cache.data.destination_airport);
+        }
+        return;
+    }
+
+    response = calloc(1, ADSBDB_RESP_BUF_SIZE);
+    if (response == NULL) {
+        return;
+    }
+
+    if (callsign != NULL && callsign[0] != '\0' && strcmp(callsign, "N/A") != 0) {
+        snprintf(url, sizeof(url), "https://api.adsbdb.com/v0/aircraft/%s?callsign=%s", icao24, callsign);
+    } else {
+        snprintf(url, sizeof(url), "https://api.adsbdb.com/v0/aircraft/%s", icao24);
+    }
+
+    if (http_get_json(url, response, ADSBDB_RESP_BUF_SIZE) != ESP_OK) {
+        free(response);
+        return;
+    }
+
+    root = cJSON_Parse(response);
+    free(response);
+    response = NULL;
+    if (!cJSON_IsObject(root)) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    resp_obj = cJSON_GetObjectItem(root, "response");
+    if (cJSON_IsObject(resp_obj)) {
+        cJSON *aircraft = cJSON_GetObjectItem(resp_obj, "aircraft");
+        cJSON *flightroute = cJSON_GetObjectItem(resp_obj, "flightroute");
+
+        if (cJSON_IsObject(aircraft)) {
+            copy_json_string(aircraft, "registration", info->registration, sizeof(info->registration));
+            copy_json_string(aircraft, "icao_type", info->aircraft_type_code, sizeof(info->aircraft_type_code));
+            copy_json_string(aircraft, "type", info->aircraft_type_name, sizeof(info->aircraft_type_name));
+        }
+
+        if (cJSON_IsObject(flightroute)) {
+            cJSON *origin = cJSON_GetObjectItem(flightroute, "origin");
+            cJSON *destination = cJSON_GetObjectItem(flightroute, "destination");
+
+            if (cJSON_IsObject(origin)) {
+                copy_json_string(origin, "iata_code", info->origin_airport, sizeof(info->origin_airport));
+                if (info->origin_airport[0] == '\0') {
+                    copy_json_string(origin, "icao_code", info->origin_airport, sizeof(info->origin_airport));
+                }
+            }
+            if (cJSON_IsObject(destination)) {
+                copy_json_string(destination, "iata_code", info->destination_airport, sizeof(info->destination_airport));
+                if (info->destination_airport[0] == '\0') {
+                    copy_json_string(destination, "icao_code", info->destination_airport, sizeof(info->destination_airport));
+                }
+            }
+        }
+    }
+
+    cJSON_Delete(root);
+
+    memset(&s_enrichment_cache, 0, sizeof(s_enrichment_cache));
+    s_enrichment_cache.valid = true;
+    snprintf(s_enrichment_cache.icao24, sizeof(s_enrichment_cache.icao24), "%s", icao24);
+    snprintf(s_enrichment_cache.callsign, sizeof(s_enrichment_cache.callsign), "%s", (callsign != NULL) ? callsign : "");
+    s_enrichment_cache.data = *info;
+}
+
 esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
 {
     char *response = NULL;
@@ -264,6 +569,8 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
     float best_dist = 1000000.0f;
     bool found = false;
     aircraft_info_t best = {0};
+    char best_icao24[16] = {0};
+    int64_t states_time_unix = 0;
 
     if (out_info == NULL) {
         return ESP_ERR_INVALID_ARG;
@@ -289,6 +596,12 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
     }
 
     states = cJSON_GetObjectItem(root, "states");
+    {
+        cJSON *time_item = cJSON_GetObjectItem(root, "time");
+        if (cJSON_IsNumber(time_item)) {
+            states_time_unix = (int64_t)time_item->valuedouble;
+        }
+    }
     if (!cJSON_IsArray(states)) {
         cJSON_Delete(root);
         return ESP_ERR_NOT_FOUND;
@@ -296,6 +609,7 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
 
     for (i = 0; i < (size_t)cJSON_GetArraySize(states); i++) {
         cJSON *state = cJSON_GetArrayItem(states, (int)i);
+        cJSON *icao24_item;
         cJSON *callsign_item;
         cJSON *lon_item;
         cJSON *lat_item;
@@ -310,11 +624,13 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
         int heading = -1;
         int altitude = -1;
         char callsign[16] = "N/A";
+        char icao24[16] = {0};
 
         if (!cJSON_IsArray(state) || cJSON_GetArraySize(state) < 14) {
             continue;
         }
 
+        icao24_item = cJSON_GetArrayItem(state, 0);
         callsign_item = cJSON_GetArrayItem(state, 1);
         lon_item = cJSON_GetArrayItem(state, 5);
         lat_item = cJSON_GetArrayItem(state, 6);
@@ -353,6 +669,10 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
                 snprintf(callsign, sizeof(callsign), "N/A");
             }
         }
+        if (cJSON_IsString(icao24_item) && icao24_item->valuestring != NULL) {
+            snprintf(icao24, sizeof(icao24), "%s", icao24_item->valuestring);
+            trim_spaces(icao24);
+        }
 
         dist = haversine_km(home_lat, home_lon, lat, lon);
         if (dist < best_dist) {
@@ -363,6 +683,7 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
             best.altitude_m = altitude;
             best.heading_deg = heading;
             snprintf(best.callsign, sizeof(best.callsign), "%s", callsign);
+            snprintf(best_icao24, sizeof(best_icao24), "%s", icao24);
             found = true;
         }
     }
@@ -371,6 +692,11 @@ esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info)
 
     if (!found) {
         return ESP_ERR_NOT_FOUND;
+    }
+
+    fill_from_adsbdb(best_icao24, best.callsign, &best);
+    if (best.origin_airport[0] == '\0' && best.destination_airport[0] == '\0') {
+        fill_route_from_recent_flights(best_icao24, best.callsign, states_time_unix, &best);
     }
 
     *out_info = best;

--- a/main/aircraft_tracker.h
+++ b/main/aircraft_tracker.h
@@ -7,9 +7,14 @@
 typedef struct {
     bool valid;
     char callsign[16];
+    char registration[16];
+    char aircraft_type_code[16];
+    char aircraft_type_name[48];
     float distance_km;
     int altitude_m;
     int heading_deg;
+    char origin_airport[8];
+    char destination_airport[8];
 } aircraft_info_t;
 
 esp_err_t aircraft_tracker_fetch_nearest(aircraft_info_t *out_info);

--- a/main/hello_world_main.c
+++ b/main/hello_world_main.c
@@ -4,6 +4,7 @@
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
+#include "driver/ledc.h"
 #include "driver/spi_master.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_vendor.h"
@@ -26,13 +27,22 @@ static SemaphoreHandle_t s_aircraft_mutex = NULL;
 static aircraft_info_t s_latest_aircraft = {0};
 static bool s_aircraft_data_ready = false;
 static bool s_led_aircraft_visible = false;
+static uint8_t s_backlight_percent = 255;
 
 #define LVGL_DRAW_BUF_LINES 40
+#define LCD_BACKLIGHT_FREQ_HZ 5000
+#define LCD_BACKLIGHT_TIMER LEDC_TIMER_0
+#define LCD_BACKLIGHT_MODE LEDC_LOW_SPEED_MODE
+#define LCD_BACKLIGHT_CHANNEL LEDC_CHANNEL_0
+#define LCD_BACKLIGHT_DUTY_RES LEDC_TIMER_10_BIT
+#define LCD_BACKLIGHT_PERCENT_IDLE 20
+#define LCD_BACKLIGHT_PERCENT_ACTIVE 100
 
 // Function declarations
 static void aircraft_tracker_task(void *pvParameters);
 static void update_display_status(void);
 static void update_aircraft_led(bool should_be_on);
+static void set_backlight_percent(uint8_t percent);
 
 // ST7789 initialization commands
 typedef struct {
@@ -131,6 +141,26 @@ static void update_aircraft_led(bool should_be_on)
     s_led_aircraft_visible = should_be_on;
 }
 
+static void set_backlight_percent(uint8_t percent)
+{
+    if (percent > 100) {
+        percent = 100;
+    }
+    if (percent == s_backlight_percent) {
+        return;
+    }
+
+    const uint32_t max_duty = (1U << LCD_BACKLIGHT_DUTY_RES) - 1U;
+    uint32_t duty = (max_duty * percent) / 100U;
+    if (LCD_BK_LIGHT_ON_LEVEL == 0) {
+        duty = max_duty - duty;
+    }
+
+    ledc_set_duty(LCD_BACKLIGHT_MODE, LCD_BACKLIGHT_CHANNEL, duty);
+    ledc_update_duty(LCD_BACKLIGHT_MODE, LCD_BACKLIGHT_CHANNEL);
+    s_backlight_percent = percent;
+}
+
 static void update_display_status(void)
 {
     if (status_label == NULL) return;
@@ -149,18 +179,40 @@ static void update_display_status(void)
     
     switch (wifi_status) {
         case WIFI_STATUS_CONNECTED:
-            snprintf(status_text, sizeof(status_text), "WiFi: Connected\n");
             if (aircraft_ready && aircraft.valid) {
-                snprintf(status_text + strlen(status_text), sizeof(status_text) - strlen(status_text),
+                char route_text[32];
+                char type_text[64];
+                const char *from = (aircraft.origin_airport[0] != '\0') ? aircraft.origin_airport : "?";
+                const char *to = (aircraft.destination_airport[0] != '\0') ? aircraft.destination_airport : "?";
+                if (aircraft.origin_airport[0] != '\0' || aircraft.destination_airport[0] != '\0') {
+                    snprintf(route_text, sizeof(route_text), "%s -> %s", from, to);
+                } else {
+                    snprintf(route_text, sizeof(route_text), "n/a");
+                }
+                if (aircraft.aircraft_type_name[0] != '\0' || aircraft.aircraft_type_code[0] != '\0') {
+                    snprintf(type_text, sizeof(type_text), "%s%s%s",
+                             aircraft.aircraft_type_code[0] ? aircraft.aircraft_type_code : "",
+                             (aircraft.aircraft_type_code[0] && aircraft.aircraft_type_name[0]) ? " " : "",
+                             aircraft.aircraft_type_name[0] ? aircraft.aircraft_type_name : "");
+                } else {
+                    snprintf(type_text, sizeof(type_text), "n/a");
+                }
+
+                snprintf(status_text, sizeof(status_text),
                          "Aircraft: %s\n"
+                         "Type: %s\n"
                          "Dist: %.1f km Alt: %d m\n"
-                         "Head: %d deg",
+                         "Head: %d deg\n"
+                         "Route: %s",
                          aircraft.callsign,
+                         type_text,
                          aircraft.distance_km,
                          aircraft.altitude_m,
-                         aircraft.heading_deg);
+                         aircraft.heading_deg,
+                         route_text);
             } else {
-                snprintf(status_text + strlen(status_text), sizeof(status_text) - strlen(status_text),
+                snprintf(status_text, sizeof(status_text),
+                         "WiFi: Connected\n"
                          "Aircraft: no data");
             }
             break;
@@ -188,6 +240,7 @@ static void update_display_status(void)
     );
 
     update_aircraft_led(aircraft_visible);
+    set_backlight_percent(aircraft_visible ? LCD_BACKLIGHT_PERCENT_ACTIVE : LCD_BACKLIGHT_PERCENT_IDLE);
 
     lv_label_set_text(status_label, status_text);
 }
@@ -245,17 +298,31 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_lcd_panel_set_gap(panel_handle, 0, 35));
     vTaskDelay(pdMS_TO_TICKS(100));
     
-    // Initialize LCD backlight
-    gpio_config_t bk_gpio_config = {
-        .pin_bit_mask = 1ULL << PIN_NUM_LCD_BL,
-        .mode = GPIO_MODE_OUTPUT,
+    // Initialize LCD backlight PWM
+    ledc_timer_config_t backlight_timer = {
+        .speed_mode = LCD_BACKLIGHT_MODE,
+        .timer_num = LCD_BACKLIGHT_TIMER,
+        .duty_resolution = LCD_BACKLIGHT_DUTY_RES,
+        .freq_hz = LCD_BACKLIGHT_FREQ_HZ,
+        .clk_cfg = LEDC_AUTO_CLK,
     };
-    ESP_ERROR_CHECK(gpio_config(&bk_gpio_config));
+    ESP_ERROR_CHECK(ledc_timer_config(&backlight_timer));
+
+    ledc_channel_config_t backlight_channel = {
+        .gpio_num = PIN_NUM_LCD_BL,
+        .speed_mode = LCD_BACKLIGHT_MODE,
+        .channel = LCD_BACKLIGHT_CHANNEL,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = LCD_BACKLIGHT_TIMER,
+        .duty = 0,
+        .hpoint = 0,
+    };
+    ESP_ERROR_CHECK(ledc_channel_config(&backlight_channel));
     
-    // Turn on display and backlight
+    // Turn on display and set initial backlight level
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_handle, true));
     vTaskDelay(pdMS_TO_TICKS(100));
-    gpio_set_level(PIN_NUM_LCD_BL, LCD_BK_LIGHT_ON_LEVEL);
+    set_backlight_percent(LCD_BACKLIGHT_PERCENT_IDLE);
 
     // Initialize LVGL
     lv_init();

--- a/main/hello_world_main.c
+++ b/main/hello_world_main.c
@@ -25,16 +25,14 @@ static lv_obj_t *status_label = NULL; // Label for WiFi status
 static SemaphoreHandle_t s_aircraft_mutex = NULL;
 static aircraft_info_t s_latest_aircraft = {0};
 static bool s_aircraft_data_ready = false;
+static bool s_led_aircraft_visible = false;
 
 #define LVGL_DRAW_BUF_LINES 40
 
-// Demo counter for RGB LED effects
-// static uint32_t demo_counter = 0; // Currently unused
-
 // Function declarations
-static void rgb_led_demo_task(void *pvParameters);
 static void aircraft_tracker_task(void *pvParameters);
 static void update_display_status(void);
+static void update_aircraft_led(bool should_be_on);
 
 // ST7789 initialization commands
 typedef struct {
@@ -94,60 +92,6 @@ static void st7789_send_init_commands(esp_lcd_panel_io_handle_t io_handle)
     }
 }
 
-static void rgb_led_demo_task(void *pvParameters)
-{
-    ESP_LOGI(TAG, "RGB LED demo task started");
-    
-    // Check if RGB LED is available
-    if (!rgb_led_is_initialized()) {
-        ESP_LOGW(TAG, "RGB LED not initialized, demo task exiting");
-        vTaskDelete(NULL);
-        return;
-    }
-    
-    const rgb_led_mode_t demo_modes[] = {
-        RGB_MODE_RAINBOW,
-        RGB_MODE_BLINK, 
-        RGB_MODE_BREATHE,
-        RGB_MODE_FLIGHT_STATUS
-    };
-    
-    const uint32_t demo_periods[] = {
-        100,  // Rainbow - fast
-        500,  // Blink - medium
-        150,  // Breathe - slow breathing
-        800   // Flight status - slower
-    };
-    
-    const char* mode_names[] = {
-        "Rainbow",
-        "Blink",
-        "Breathe", 
-        "Flight Status"
-    };
-    
-    uint8_t mode_index = 0;
-    const uint8_t num_modes = sizeof(demo_modes) / sizeof(demo_modes[0]);
-    
-    while (1) {
-        ESP_LOGI(TAG, "RGB LED Demo: %s mode for 10 seconds", mode_names[mode_index]);
-        
-        // Set current mode (function handles null checks internally)
-        esp_err_t ret = rgb_led_set_mode(demo_modes[mode_index], demo_periods[mode_index]);
-        if (ret != ESP_OK) {
-            ESP_LOGW(TAG, "RGB LED not available, demo task exiting");
-            vTaskDelete(NULL); // Delete this task
-            return;
-        }
-        
-        // Wait 10 seconds
-        vTaskDelay(pdMS_TO_TICKS(10000));
-        
-        // Move to next mode
-        mode_index = (mode_index + 1) % num_modes;
-    }
-}
-
 static void aircraft_tracker_task(void *pvParameters)
 {
     while (1) {
@@ -170,6 +114,21 @@ static void aircraft_tracker_task(void *pvParameters)
         }
         vTaskDelay(pdMS_TO_TICKS(TRACKER_REFRESH_SEC * 1000));
     }
+}
+
+static void update_aircraft_led(bool should_be_on)
+{
+    if (!rgb_led_is_initialized() || should_be_on == s_led_aircraft_visible) {
+        return;
+    }
+
+    if (should_be_on) {
+        rgb_led_set_color((rgb_color_t)RGB_GREEN);
+    } else {
+        rgb_led_off();
+    }
+
+    s_led_aircraft_visible = should_be_on;
 }
 
 static void update_display_status(void)
@@ -222,6 +181,14 @@ static void update_display_status(void)
             break;
     }
     
+    const bool aircraft_visible = (
+        wifi_status == WIFI_STATUS_CONNECTED &&
+        aircraft_ready &&
+        aircraft.valid
+    );
+
+    update_aircraft_led(aircraft_visible);
+
     lv_label_set_text(status_label, status_text);
 }
 
@@ -312,10 +279,13 @@ void app_main(void)
     disp_drv.user_data = panel_handle;
     lv_disp_drv_register(&disp_drv);
 
+    lv_obj_set_style_bg_color(lv_scr_act(), lv_color_black(), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(lv_scr_act(), LV_OPA_COVER, LV_PART_MAIN);
+
     // Create a label for status display
     status_label = lv_label_create(lv_scr_act());
     lv_label_set_text(status_label, "WiFi: Connecting...\nAircraft: waiting");
-    lv_obj_set_style_text_font(status_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_font(status_label, &lv_font_montserrat_18, 0);
     lv_obj_set_style_text_color(status_label, lv_color_white(), 0);
     lv_obj_set_style_text_align(status_label, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_center(status_label);
@@ -345,12 +315,7 @@ void app_main(void)
     esp_err_t rgb_ret = rgb_led_init();
     if (rgb_ret == ESP_OK) {
         ESP_LOGI(TAG, "RGB LED initialized successfully");
-        
-        // Start with rainbow effect
-        rgb_led_set_mode(RGB_MODE_RAINBOW, 100);
-        
-        // Create a task for LED demo
-        xTaskCreate(rgb_led_demo_task, "rgb_demo", 4096, NULL, 3, NULL);
+        rgb_led_off();
     } else {
         ESP_LOGE(TAG, "RGB LED initialization failed: %s", esp_err_to_name(rgb_ret));
         ESP_LOGW(TAG, "Continuing without RGB LED functionality");

--- a/main/hello_world_main.c
+++ b/main/hello_world_main.c
@@ -177,8 +177,6 @@ static void update_display_status(void)
     if (status_label == NULL) return;
     
     char status_text[256];
-    char ip_str[16];
-    int8_t rssi;
     aircraft_info_t aircraft = {0};
     bool aircraft_ready = false;
     
@@ -192,18 +190,7 @@ static void update_display_status(void)
     
     switch (wifi_status) {
         case WIFI_STATUS_CONNECTED:
-            if (wifi_manager_get_info(ip_str, &rssi) == ESP_OK) {
-                snprintf(status_text, sizeof(status_text), 
-                         "FLIGHT CONTROLLER\n"
-                         "WiFi: Connected\n"
-                         "IP: %s\n"
-                         "RSSI: %d dBm\n", 
-                         ip_str, rssi);
-            } else {
-                snprintf(status_text, sizeof(status_text), 
-                         "FLIGHT CONTROLLER\n"
-                         "WiFi: Connected\n");
-            }
+            snprintf(status_text, sizeof(status_text), "WiFi: Connected\n");
             if (aircraft_ready && aircraft.valid) {
                 snprintf(status_text + strlen(status_text), sizeof(status_text) - strlen(status_text),
                          "Aircraft: %s\n"
@@ -220,19 +207,16 @@ static void update_display_status(void)
             break;
         case WIFI_STATUS_CONNECTING:
             snprintf(status_text, sizeof(status_text), 
-                     "FLIGHT CONTROLLER\n"
                      "WiFi: Connecting...\n"
                      "Aircraft: waiting");
             break;
         case WIFI_STATUS_FAILED:
             snprintf(status_text, sizeof(status_text), 
-                     "FLIGHT CONTROLLER\n"
                      "WiFi: Failed to connect\n"
                      "Aircraft: unavailable");
             break;
         default:
             snprintf(status_text, sizeof(status_text), 
-                     "FLIGHT CONTROLLER\n"
                      "WiFi: Disconnected\n"
                      "Aircraft: unavailable");
             break;
@@ -330,7 +314,7 @@ void app_main(void)
 
     // Create a label for status display
     status_label = lv_label_create(lv_scr_act());
-    lv_label_set_text(status_label, "FLIGHT CONTROLLER\nInitializing...");
+    lv_label_set_text(status_label, "WiFi: Connecting...\nAircraft: waiting");
     lv_obj_set_style_text_font(status_label, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(status_label, lv_color_white(), 0);
     lv_obj_set_style_text_align(status_label, LV_TEXT_ALIGN_CENTER, 0);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new HTTP calls to third-party enrichment endpoints (ADSBDB + OpenSky flights) and expands UI/LED/backlight control, which could affect network reliability, latency, and memory usage on-device.
> 
> **Overview**
> **Enriches nearest-aircraft results** beyond OpenSky `states/all` by capturing `icao24` and fetching best-effort aircraft details (type/registration) and route via `api.adsbdb.com`, with a fallback route lookup using OpenSky `/api/flights/aircraft`; OpenSky auth header setup is refactored into `set_auth_header_if_available` and `aircraft_info_t` is expanded to carry the new fields.
> 
> **Updates the LCD/UX** to show aircraft type and route (and simplifies WiFi display), adds an “aircraft visible” indicator via the RGB LED, and switches the LCD backlight from a GPIO on/off to LEDC PWM with idle vs active brightness levels; the RGB LED demo task is removed and the LVGL screen styling/text are adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a786e0cc155800a12ae7e4bc8d11383cbdc506e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->